### PR TITLE
Add platform type validation for refresh token

### DIFF
--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -286,7 +286,7 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 		}
 
 		if (tokenPlatformType !== this._platformType) {
-			throw new Error('Token platform is different from the platform type of this LoginSession instance');
+			throw new Error('Token platform type is different from the platform type of this LoginSession instance');
 		}
 
 		if (

--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -274,6 +274,21 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 			throw new Error('The provided token is an access token, not a refresh token');
 		}
 
+		let tokenPlatformType: EAuthTokenPlatformType;
+		if (aud.includes('client')) {
+			tokenPlatformType = EAuthTokenPlatformType.SteamClient;
+		} else if (aud.includes('mobile')) {
+			tokenPlatformType = EAuthTokenPlatformType.MobileApp;
+		} else if (aud.includes('web')) {
+			tokenPlatformType = EAuthTokenPlatformType.WebBrowser;
+		} else {
+			throw new Error('Platform type of token is unknown');
+		}
+
+		if (tokenPlatformType != this._platformType) {
+			throw new Error('Token platform is different from the platform type of this LoginSession instance');
+		}
+
 		if (
 			this._startSessionResponse
 			&& (this._startSessionResponse as StartAuthSessionWithCredentialsResponse).steamId

--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -285,7 +285,7 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 			throw new Error('Platform type of token is unknown');
 		}
 
-		if (tokenPlatformType != this._platformType) {
+		if (tokenPlatformType !== this._platformType) {
 			throw new Error('Token platform is different from the platform type of this LoginSession instance');
 		}
 


### PR DESCRIPTION
Now we don't validate this part of refresh token.
That may have issues.

For example, if user accidentally pass `EAuthTokenPlatformType.WebBrowser` for `LoginSession` constructor, then provide refresh token from **Client** and then call `getWebCookies()` - SteamSession will think that provided token is really SteamWeb token and tries to get cookies from web-endpoints, in result refresh token will be canceled by Steam backend (https://github.com/DoctorMcKay/node-steam-session/issues/22).

Better will be updating platform type, instead of throwing error, but it will cause updating transport, which defining in constructor and you may not want to change this.

If you will accept this PR, i suggest to bump version to 1.3.0, because throwing error here may contain breaking changes for some projects.