### PR TITLE
feat/add-custom-agents-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ event is emitted.
     - `socksProxy` - A string containing a URI for a SOCKS proxy. For example, `socks5://user:pass@1.2.3.4:1080`
     - `agent` - An `https.Agent` instance to use for requests. If omitted, a new `https.Agent` will be created
       internally.
+- You can't use `httpProxy`, `socksProxy` or `agent` at the same time. If you try to use more than one of them, an Error will be thrown.
 
 Constructs a new `LoginSession` instance. Example usage:
 
@@ -569,6 +570,9 @@ If this is a `string`, it must be either hex- or base64-encoded.
 	  If omitted, defaults to a `WebApiTransport` instance. In all likelihood, you don't need to use this.
 	- `httpProxy` - A string containing a URI for an HTTP proxy. For example, `http://user:pass@1.2.3.4:80`
 	- `socksProxy` A string containing a URI for a SOCKS proxy. For example, `socks5://user:pass@1.2.3.4:1080`
+    - `agent` - An `https.Agent` instance to use for requests. If omitted, a new `https.Agent` will be created
+      internally.
+- You can't use `httpProxy`, `socksProxy` or `agent` at the same time. If you try to use more than one of them, an Error will be thrown.
 
 Constructs a new `LoginApprover` instance. Example usage:
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ event is emitted.
 		If omitted, defaults to a `WebSocketCMTransport` instance for `SteamClient` platform types, and a 
 		`WebApiTransport` instance for all other platform types. In all likelihood, you don't need to use this.
     - `httpProxy` - A string containing a URI for an HTTP proxy. For example, `http://user:pass@1.2.3.4:80`
-    - `socksProxy` A string containing a URI for a SOCKS proxy. For example, `socks5://user:pass@1.2.3.4:1080`
+    - `socksProxy` - A string containing a URI for a SOCKS proxy. For example, `socks5://user:pass@1.2.3.4:1080`
+    - `agent` - An `https.Agent` instance to use for requests. If omitted, a new `https.Agent` will be created
+      internally.
 
 Constructs a new `LoginSession` instance. Example usage:
 

--- a/src/LoginApprover.ts
+++ b/src/LoginApprover.ts
@@ -20,7 +20,7 @@ export default class LoginApprover {
 	private _handler: AuthenticationClient;
 
 	constructor(accessToken: string, sharedSecret: string|Buffer, options?: ConstructorOptions) {
-		let agent:HTTPS.Agent = new HTTPS.Agent({keepAlive: true});
+		let agent:HTTPS.Agent = options.agent || new HTTPS.Agent({keepAlive: true});
 		if (options.httpProxy && options.socksProxy) {
 			throw new Error('Cannot specify both httpProxy and socksProxy at the same time');
 		}

--- a/src/LoginApprover.ts
+++ b/src/LoginApprover.ts
@@ -20,10 +20,11 @@ export default class LoginApprover {
 	private _handler: AuthenticationClient;
 
 	constructor(accessToken: string, sharedSecret: string|Buffer, options?: ConstructorOptions) {
-		let agent:HTTPS.Agent = options.agent || new HTTPS.Agent({keepAlive: true});
-		if (options.httpProxy && options.socksProxy) {
-			throw new Error('Cannot specify both httpProxy and socksProxy at the same time');
+		if (options.httpProxy && options.socksProxy || options.agent && (options.httpProxy || options.socksProxy)) {
+			throw new Error('Cannot specify both httpProxy, socksProxy or agent at the same time');
 		}
+
+		let agent:HTTPS.Agent = options.agent || new HTTPS.Agent({keepAlive: true});
 
 		if (options.httpProxy) {
 			agent = StdLib.HTTP.getProxyAgent(true, options.httpProxy) as HTTPS.Agent;

--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -104,7 +104,7 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 
 		options = options || {};
 
-		let agent:HTTPS.Agent = new HTTPS.Agent({keepAlive: true});
+		let agent:HTTPS.Agent = options.agent || new HTTPS.Agent({keepAlive: true});
 		if (options.httpProxy && options.socksProxy) {
 			throw new Error('Cannot specify both httpProxy and socksProxy at the same time');
 		}

--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -104,10 +104,11 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 
 		options = options || {};
 
-		let agent:HTTPS.Agent = options.agent || new HTTPS.Agent({keepAlive: true});
-		if (options.httpProxy && options.socksProxy) {
-			throw new Error('Cannot specify both httpProxy and socksProxy at the same time');
+		if (options.httpProxy && options.socksProxy || options.agent && (options.httpProxy || options.socksProxy)) {
+			throw new Error('Cannot specify both httpProxy, socksProxy or agent at the same time');
 		}
+
+		let agent:HTTPS.Agent = options.agent || new HTTPS.Agent({keepAlive: true});
 
 		if (options.httpProxy) {
 			agent = StdLib.HTTP.getProxyAgent(true, options.httpProxy) as HTTPS.Agent;

--- a/src/interfaces-external.ts
+++ b/src/interfaces-external.ts
@@ -6,6 +6,8 @@
  * @module method-params
  */
 
+import HTTPS from 'https';
+
 import ESessionPersistence from './enums-steam/ESessionPersistence';
 import EAuthSessionGuardType from './enums-steam/EAuthSessionGuardType';
 import EAuthTokenPlatformType from './enums-steam/EAuthTokenPlatformType';
@@ -29,6 +31,11 @@ export interface ConstructorOptions {
 	 * A string containing a URI for an HTTP proxy. For example, `http://user:pass@1.2.3.4:80`
 	 */
 	httpProxy?: string
+
+	/**
+	 * An `https.Agent` instance to use for requests. If omitted, a new `https.Agent` will be created internally.
+	 */
+	agent?: HTTPS.Agent
 }
 
 export interface StartLoginSessionWithCredentialsDetails {


### PR DESCRIPTION
Add ability to pass custom agents. Useful if required to use one agent for all steam requests.