### PR TITLE
fix creation webcookeis for `EAuthTokenPlatformType.WebBrowser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ attempt if you already have a valid refresh token. Returns a Promise.
 On failure, the Promise will be rejected. Depending on the nature of the failure, an EResult may or may not be available.
 
 On success, the Promise will be resolved with an array of strings. Each string contains a cookie, e.g.
-`'steamLoginSecure=blahblahblahblah'`.
+`'steamLoginSecure=blahblahblahblah; Path=/; Secure; HttpOnly; SameSite=None; Domain=steamcommunity.com'`.
 
 Here's an example of how you can get new web cookies when you already have a valid refresh token:
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,12 @@ attempt if you already have a valid refresh token. Returns a Promise.
 On failure, the Promise will be rejected. Depending on the nature of the failure, an EResult may or may not be available.
 
 On success, the Promise will be resolved with an array of strings. Each string contains a cookie, e.g.
-`'steamLoginSecure=blahblahblahblah; Path=/; Secure; HttpOnly; SameSite=None; Domain=steamcommunity.com'`.
+
+`steamLoginSecure=blahblahblahblah` 
+
+or
+
+`steamLoginSecure=blahblahblahblah; Path=/; Secure; HttpOnly; SameSite=None; Domain=steamcommunity.com`
 
 Here's an example of how you can get new web cookies when you already have a valid refresh token:
 

--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -865,7 +865,7 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 				return reject(new Error('No steamLoginSecure cookie in result'));
 			}
 
-			const domain = new URL(url).host;
+			let domain = new URL(url).host;
 			resolve(result.headers['set-cookie'].map(cookie => `${cookie}; Domain=${domain}`));
 		}));
 


### PR DESCRIPTION
Valve (again) change web authorization. Now we have different cookies for all subdomains.

Eg. cookies from `steamcommunity.com` now we can't use for `store.steampowered.com`, etc.
New access token `audience`:

`store.steampowered.com`
```json
"aud": [
    "web:store"
]
```
  
`steamcommunity.com`
```json
"aud": [
    "web:community"
]
```
Only fair for creation cookies with `EAuthTokenPlatformType.WebBrowser`.
`EAuthTokenPlatformType.SteamClient` and `EAuthTokenPlatformType.MobileApp` still creates cookies with common `audience`: 

```json
"aud": [
    "web",
    "mobile"
]
```

So, will be better to return full cookies strings with `Domain` attribute.
Will require some changes on client side, but popular packages that maintain cookies (CookieJar) automatically can use full and short variants.