### PR TITLE
Better webcookies handling

### DIFF
--- a/src/LoginSession.ts
+++ b/src/LoginSession.ts
@@ -874,7 +874,11 @@ export default class LoginSession extends TypedEmitter<LoginSessionEvents> {
 		cookies = cookies.filter(cookie => !cookie.startsWith('sessionid='));
 
 		// Now add in a sessionid cookie
-		cookies.push(`sessionid=${sessionId}`);
+		[
+			...new Set(cookies.map(cookie => cookie.split('Domain=')[1].split(';')[0]))
+		]
+			.filter(domain => domain !== 'login.steampowered.com')
+			.forEach(domain => cookies.push(`sessionid=${sessionId}; Path=/; Secure; SameSite=None; Domain=${domain}`));
 
 		return cookies;
 	}


### PR DESCRIPTION
Now we can return cookies for `login.steampowered.com` for `EAuthTokenPlatformType.WebBrowser` to match official behavior. Doing that we can automatically refresh cookies, without need to use `LogginSession.getWebCookies()` again. 
After `steamLoginSecure` expires, any request to steam redirects us to `login.steampowered`, which updates our cookies and redirects back. Just like browsers do.

Also, now `sessionid` sets properly and not conflicts with jar libs (due to lack of domain).